### PR TITLE
Prevent crashes when a line contains a splitter.

### DIFF
--- a/hape/hape_libs/utils/havenask_dataset.py
+++ b/hape/hape_libs/utils/havenask_dataset.py
@@ -58,7 +58,7 @@ class HavenaskDataSet:
         raw_doc = ""
         raw_doc_dict = {}
         for line in lines:
-            if line.find(self.kv_sep) != -1:
+            if line.find(self.kv_sep) == 1:
                 key, value = line.split(self.kv_sep)
                 value = value[:value.find(HavenaskDataSet.field_sep)]
                 raw_doc_dict[key] = value


### PR DESCRIPTION
Traceback (most recent call last):
  File "example/common/case.py", line 154, in <module>
    cli()
  File "\~/.local/lib/python2.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "\~/.local/lib/python2.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "\~/.local/lib/python2.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "\~/.local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "\~/.local/lib/python2.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "example/common/case.py", line 94, in run
    full_dataset.parse()
  File "\~/havenask/hape/hape_libs/utils/havenask_dataset.py", line 69, in parse
    key, value = line.split(self.kv_sep)
ValueError: too many values to unpack