### PR TITLE
Fix full builder when index number over 10

### DIFF
--- a/aios/hippo/src/sdk/default/CmdExecutor.cpp
+++ b/aios/hippo/src/sdk/default/CmdExecutor.cpp
@@ -105,7 +105,7 @@ bool CmdExecutor::addUser(const string &address,
 bool CmdExecutor::checkContainerExist(const string &address,
                                       const string &containerName)
 {
-    string checkCmd = _dockerExeName + " ps |grep " + containerName;
+    string checkCmd = _dockerExeName + " ps --format {{.Names}} | grep ^" + containerName + "$";
     string cmd;
     generateCmd(address, checkCmd, cmd);
     string msg;

--- a/aios/tools/hape/hape_libs/appmaster/docker/docker_util.py
+++ b/aios/tools/hape/hape_libs/appmaster/docker/docker_util.py
@@ -7,7 +7,7 @@ class DockerContainerUtil():
     @staticmethod
     def check_container(ip, name):
         shell = SSHShell(ip)
-        check_command = "docker ps --format '{{{{.Names}}}}' | grep -e ^{}$".format(name)
+        check_command = "docker ps --format {{{{.Names}}}} | grep ^{}$".format(name)
         out = shell.execute_command(check_command)
         if len(out.strip()) != 0:
             Logger.info("Container {} is started in {}".format(name, ip))
@@ -45,8 +45,10 @@ class DockerContainerUtil():
         
         command = "docker exec -t {} bash -c \"cp /home/.passwd /etc/passwd && cp /home/.group /etc/group\"".format(name)
         shell.execute_command(command)
-        
-        command = "docker exec -t --user {} {} bash -c \"mkdir {}\"".format(user, name, workdir)
+
+        if isinstance(user, tuple):
+            user = user[0]
+        command = "docker exec -t --user {} {} bash -c \"mkdir -p {}\"".format(user, name, workdir)
         shell.execute_command(command)
         
         if not DockerContainerUtil.check_container(ip, name):
@@ -123,4 +125,4 @@ class DockerContainerUtil():
     def stop_container(ip, name):
         Logger.info("Stop container {} in {}".format(name, ip))
         shell = SSHShell(ip)
-        shell.execute_command("docker ps --all --format {{{{.Names}}}} | grep {} | xargs docker rm -f".format(name))
+        shell.execute_command("docker ps --all --format {{{{.Names}}}} | grep ^{}$ | xargs docker rm -f".format(name))

--- a/aios/tools/hape/hape_libs/clusters/bs/bs.py
+++ b/aios/tools/hape/hape_libs/clusters/bs/bs.py
@@ -53,7 +53,7 @@ class BsCluster(ClusterBase):
                     processor_status.processorStatus = ProcessorStatusType.RUNNING
                     status_list.append(processor_status)
                 else:
-                    if table != None and worker_status.role.find(table) == -1:
+                    if table != None and worker_status.role.find("."+table+".") == -1:
                         continue
                     processor_status  = ClusterProcessorStatus.from_hippo_worker_info(worker_status)
                     processor_status.processorName = self._global_config.get_worker_command(self._key)

--- a/aios/tools/hape/hape_libs/commands/validate_cmd.py
+++ b/aios/tools/hape/hape_libs/commands/validate_cmd.py
@@ -81,14 +81,15 @@ def validate_schedule(key, admin_ip, worker_ip, domain_config):
 --cpu-period=100000 --memory=5124m -v /etc/passwd:/home/.passwd -v /etc/group:/home/.group --name {} {} /sbin/init".format(user_home, user_home, user_home, container_name, image)
     cmd = "ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no {} '{}'".format(worker_ip, run_cmd)
     shell.execute_command(cmd)
-    check_cmd = "docker ps | grep {}".format(container_name)
+    check_cmd = "docker ps --format {{{{.Names}}}} | grep ^{}$".format(container_name)
     cmd = "ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no {} '{}'".format(worker_ip, check_cmd)
     out = shell.execute_command(cmd)
     if out.find(container_name) == -1:
         raise RuntimeError("Failed to schedule container from {} to {}".format(admin_ip, worker_ip))
     
     run_cmd = "docker rm -f {}".format(container_name)
-    shell.execute_command(run_cmd)
+    cmd = "ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no {} '{}'".format(worker_ip, run_cmd)
+    shell.execute_command(cmd)
 
     Logger.info("Succeed to schedule from {} to {}".format(admin_ip, worker_ip))
 

--- a/aios/tools/hape/hape_libs/utils/fs_wrapper.py
+++ b/aios/tools/hape/hape_libs/utils/fs_wrapper.py
@@ -118,6 +118,9 @@ class LocalClient(FsClientBase):
     
     def put(self, src, dest):
         if os.path.isfile(src):
+            dest_dir = os.path.dirname(dest)
+            if not os.path.exists(dest_dir):
+                os.makedirs(dest_dir)
             shutil.copyfile(src, dest)
         else:
             shutil.copytree(src, dest)

--- a/aios/tools/hape/hape_libs/utils/havenask_dataset.py
+++ b/aios/tools/hape/hape_libs/utils/havenask_dataset.py
@@ -59,7 +59,7 @@ class HavenaskDataSet:
         raw_doc_dict = {}
         for line in lines:
             index = line.find(self.kv_sep)
-            if line.find(self.kv_sep) != -1:
+            if index != -1:
                 key, value = line[:index], line[index+1:]
                 value = value[:value.find(HavenaskDataSet.field_sep)]
                 raw_doc_dict[key] = value


### PR DESCRIPTION
Fix when multiple containers are named x, xx, xxx, they can accurately match the corresponding containers