### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/aios/apps/facility/build_service/build_service/third_party/minizip/mz_os.c
+++ b/aios/apps/facility/build_service/build_service/third_party/minizip/mz_os.c
@@ -75,7 +75,7 @@ int32_t mz_path_remove_slash(char *path)
 int32_t mz_path_has_slash(const char *path)
 {
     int32_t path_len = (int32_t)strlen(path);
-    if (path[path_len - 1] != '\\' && path[path_len - 1] != '/')
+    if (path_len > 0 && path[path_len - 1] != '\\' && path[path_len - 1] != '/')
         return MZ_EXIST_ERROR;
     return MZ_OK;
 }


### PR DESCRIPTION
Hi Development Team,

I identified a potential vulnerability in a clone function mz_path_has_slash() in `aios/apps/facility/build_service/build_service/third_party/minizip/mz_os.c` sourced from [zlib-ng/minizip-ng](https://github.com/zlib-ng/minizip-ng). This issue, originally reported in [CVE-2023-48107](https://nvd.nist.gov/vuln/detail/CVE-2023-48107), was resolved in the repository via this commit https://github.com/zlib-ng/minizip-ng/commit/341760887456e78ed9b86b5b3008c3ddfbd96f97.

This PR applies the corresponding patch to fix the vulnerability in this codebase.

Please review at your convenience. Thank you!