### PR TITLE
修改最大支持构建版本上限

### DIFF
--- a/aios/storage/indexlib/framework/VersionLine.h
+++ b/aios/storage/indexlib/framework/VersionLine.h
@@ -60,7 +60,7 @@ public:
     bool operator==(const VersionLine& other) const;
 
 private:
-    static constexpr uint32_t KEY_NODE_COUNT = 10;
+    static constexpr uint32_t KEY_NODE_COUNT = 48;
     VersionCoord _parentVersion;
     //<fence name, version id>
     std::vector<std::pair<std::string, versionid_t>> _keyVersions;


### PR DESCRIPTION
背景：KEY_NODE_COUNT 限制了离线构建版本的最大数量，对于小时级的增量构建=10的限制太少了，无法满足1～2天内的增量构建。

解决：
修改最大支持构建版本上限，解决构建上限问题

