### PR TITLE
Fix CVE-2023-48107: Check for zero length path in mz_path_has_slash 

### DIFF
--- a/aios/apps/facility/build_service/build_service/third_party/minizip/mz_os.c
+++ b/aios/apps/facility/build_service/build_service/third_party/minizip/mz_os.c
@@ -75,7 +75,7 @@ int32_t mz_path_remove_slash(char *path)
 int32_t mz_path_has_slash(const char *path)
 {
     int32_t path_len = (int32_t)strlen(path);
-    if (path[path_len - 1] != '\\' && path[path_len - 1] != '/')
+    if (path_len > 0 && path[path_len - 1] != '\\' && path[path_len - 1] != '/')
         return MZ_EXIST_ERROR;
     return MZ_OK;
 }


### PR DESCRIPTION
修复CVE-2023-48107安全漏洞，在mz_path_has_slash函数中检查零长度路径Check for zero length path in mz_path_has_slash